### PR TITLE
Include sending of id from rdtrk cookie as client id attribute.

### DIFF
--- a/RDStationAPI.class.php
+++ b/RDStationAPI.class.php
@@ -102,7 +102,7 @@ class RDStationAPI {
 		$this->validateToken();
 		if(empty($email)) throw new Exception("Inform at least the lead email as the first argument.");
 		if(empty($data['identificador'])) $data['identificador'] = $this->defaultIdentifier;
-        if(empty($data["client_id"]) && !empty($_COOKIE["rdtrk"])) { $data["client_id"] = json_decode($_COOKIE["rdtrk"])->{'id'};}
+        if(empty($data["client_id"]) && !empty($_COOKIE["rdtrk"])) $data["client_id"] = json_decode($_COOKIE["rdtrk"])->{'id'};
     
 		$data['email'] = $email;
 

--- a/RDStationAPI.class.php
+++ b/RDStationAPI.class.php
@@ -102,7 +102,7 @@ class RDStationAPI {
 		$this->validateToken();
 		if(empty($email)) throw new Exception("Inform at least the lead email as the first argument.");
 		if(empty($data['identificador'])) $data['identificador'] = $this->defaultIdentifier;
-        if(empty($data["client_id"]) && !empty($_COOKIE["rdtrk"])) $data["client_id"] = json_decode($_COOKIE["rdtrk"])->{'id'};
+        	if(empty($data["client_id"]) && !empty($_COOKIE["rdtrk"])) $data["client_id"] = json_decode($_COOKIE["rdtrk"])->{'id'};
     
 		$data['email'] = $email;
 

--- a/RDStationAPI.class.php
+++ b/RDStationAPI.class.php
@@ -59,7 +59,7 @@ class RDStationAPI {
 	**/
 	protected function request($method="POST", $url, $data=array()){
 
-		$data['token_rdstation'] = $this->token;
+	$data['token_rdstation'] = $this->token;
     $JSONData = json_encode($data);
     $URLParts = parse_url($url);
 
@@ -102,7 +102,8 @@ class RDStationAPI {
 		$this->validateToken();
 		if(empty($email)) throw new Exception("Inform at least the lead email as the first argument.");
 		if(empty($data['identificador'])) $data['identificador'] = $this->defaultIdentifier;
-
+        if(empty($data["client_id"]) && !empty($_COOKIE["rdtrk"])) { $data["client_id"] = json_decode($_COOKIE["rdtrk"])->{'id'};}
+    
 		$data['email'] = $email;
 
 		return $this->request("POST", $this->getURL('conversions'), $data);


### PR DESCRIPTION
Inclusão do envio do id do cookie do rdtrk como client_id. Para testar deve-se ter o script de lead tracking do rdstation habilitado no website para geração do cookie. 
