### PR TITLE
Correct require call to adequate it to the client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Usage
 ```php
-require("RDStation.class.php");
+require("RDStationAPI.class.php");
 $rdAPI = new RDStation("RD_PRIVATE_TOKEN", "RD_TOKEN");
 
 //SEND NEW LEAD TO RD STATION


### PR DESCRIPTION
Just to adequate the example on the readme file to maintain consistency with the client code.
