### PR TITLE
Include Traffic Source

### DIFF
--- a/RDStationAPI.class.php
+++ b/RDStationAPI.class.php
@@ -94,6 +94,7 @@ class RDStationAPI {
 			"twitter" => "twitter.com/paulillo",
 			"facebook" => "facebook.com/paulillo",
 			"c_utmz" => "",
+			"traffic_source" => "",
 			"created_at" => "",
 			"tags" => "cofounder, hotlead"
 		);
@@ -103,6 +104,7 @@ class RDStationAPI {
 		if(empty($email)) throw new Exception("Inform at least the lead email as the first argument.");
 		if(empty($data['identificador'])) $data['identificador'] = $this->defaultIdentifier;
         	if(empty($data["client_id"]) && !empty($_COOKIE["rdtrk"])) $data["client_id"] = json_decode($_COOKIE["rdtrk"])->{'id'};
+        	if(empty($data["traffic_source"]) && !empty($_COOKIE["__trf.src"])) $data["traffic_source"] = $_COOKIE["__trf.src"];
     
 		$data['email'] = $email;
 


### PR DESCRIPTION
Include Traffic Source Cookie value if it is present. Helps to get Lead origin when utmz is not available, and the website has RD TagManager configured.
