### PR TITLE
Use API v13 for update Leads

### DIFF
--- a/RDStationAPI.class.php
+++ b/RDStationAPI.class.php
@@ -21,50 +21,50 @@ http://ajuda.rdstation.com.br/hc/pt-br/articles/200310589-Integrar-formul&aacute
 
 class RDStationAPI {
 
-	public $token;
-	public $privateToken;
-	public $baseURL = "https://www.rdstation.com.br/api/";
-	public $defaultIdentifier = "rdstation-php-integration";
+  public $token;
+  public $privateToken;
+  public $baseURL = "https://www.rdstation.com.br/api/";
+  public $defaultIdentifier = "rdstation-php-integration";
 
-	public function __construct($privateToken=NULL, $token=NULL){
-		if(empty($privateToken)) throw new Exception("Inform RDStationAPI.privateToken as the first argument.");
+  public function __construct($privateToken=NULL, $token=NULL){
+    if(empty($privateToken)) throw new Exception("Inform RDStationAPI.privateToken as the first argument.");
 
-		$this->token = $token;
-		$this->privateToken = $privateToken;
-	}
+    $this->token = $token;
+    $this->privateToken = $privateToken;
+  }
 
 	/**
 	$type:	(String) generic, leads, conversions
 	**/
   protected function getURL($type='generic', $apiVersion='1.2'){
     //(POST) https://www.rdstation.com.br/api/1.2/services/PRIVATE_TOKEN/generic //USED TO CHANGE A LEAD STATUS
-	  //(PUT) https://www.rdstation.com.br/api/1.2/leads/:lead_email //USED TO UPDATE A LEAD
-		//(POST) https://www.rdstation.com.br/api/1.2/conversions //USED TO SEND A NEW LEAD
-		switch($type){
-			case 'generic':			return $this->baseURL.$apiVersion."/services/".$this->privateToken."/generic";
-			case 'leads':				return $this->baseURL.$apiVersion."/leads/";
-			case 'conversions':	return $this->baseURL.$apiVersion."/conversions";
-		}
-	}
+    //(PUT) https://www.rdstation.com.br/api/1.2/leads/:lead_email //USED TO UPDATE A LEAD
+    //(POST) https://www.rdstation.com.br/api/1.2/conversions //USED TO SEND A NEW LEAD
+    switch($type){
+      case 'generic':			return $this->baseURL.$apiVersion."/services/".$this->privateToken."/generic";
+      case 'leads':				return $this->baseURL.$apiVersion."/leads/";
+      case 'conversions':	return $this->baseURL.$apiVersion."/conversions";
+    }
+  }
 
-	protected function validateToken(){
-		if(empty($this->token)) throw new Exception("Inform RDStation.token as the second argument when instantiating a new RDStationAPI object.");
-	}
+  protected function validateToken(){
+    if(empty($this->token)) throw new Exception("Inform RDStation.token as the second argument when instantiating a new RDStationAPI object.");
+  }
 
 	/**
 	$method:	(String) POST, PUT
 	$url:			(String) RD Station endpoint returned by $this->getURL()
 	$data:		(Array)
 	**/
-	protected function request($method="POST", $url, $data=array()){
+  protected function request($method="POST", $url, $data=array()){
 
-	$data['token_rdstation'] = $this->token;
+    $data['token_rdstation'] = $this->token;
     $JSONData = json_encode($data);
     $URLParts = parse_url($url);
 
     $fp = fsockopen($URLParts['host'],
-        isset($URLParts['port'])?$URLParts['port']:80,
-        $errno, $errstr, 30);
+                    isset($URLParts['port'])?$URLParts['port']:80,
+                    $errno, $errstr, 30);
 
     $out = $method." ".$URLParts['path']." HTTP/1.1\r\n";
     $out .= "Host: ".$URLParts['host']."\r\n";
@@ -96,48 +96,50 @@ class RDStationAPI {
 			"tags" => "cofounder, hotlead"
 		);
 	**/
-	public function sendNewLead($email, $data=array()){
-		$this->validateToken();
-		if(empty($email)) throw new Exception("Inform at least the lead email as the first argument.");
-		if(empty($data['identificador'])) $data['identificador'] = $this->defaultIdentifier;
+  public function sendNewLead($email, $data=array()){
+    $this->validateToken();
+    if(empty($email)) throw new Exception("Inform at least the lead email as the first argument.");
+    if(empty($data['identificador'])) $data['identificador'] = $this->defaultIdentifier;
     if(empty($data["client_id"]) && !empty($_COOKIE["rdtrk"])) $data["client_id"] = json_decode($_COOKIE["rdtrk"])->{'id'};
     if(empty($data["traffic_source"]) && !empty($_COOKIE["__trf_src"])) $data["traffic_source"] = $_COOKIE["__trf_src"];
 
     $data['email'] = $email;
 
-		return $this->request("POST", $this->getURL('conversions'), $data);
+    return $this->request("POST", $this->getURL('conversions'), $data);
 	}
 
 	/**
 	Helper function to update lead properties
 	**/
-	public function updateLead($email, $data=array()){
+  public function updateLead($email, $data=array()){
+    $newData = array();
     $url = $this->getURL('leads', '1.3').$email;
-    $new_data['lead'] = $data;
-    $new_data['auth_token'] = $this->privateToken;
+    $newData['lead'] = $data;
+    $newData['auth_token'] = $this->privateToken;
 
-		return $this->request("PUT", $url, $new_data);
-	}
+    return $this->request("PUT", $url, $newData);
+  }
 
 	/**
 	$email: (String) Lead email
 	$newStage: (Integer) 0 - Lead, 1 - Qualified Lead, 2 - Customer
 	$opportunity: (Integer) true or false
 	**/
-	public function updateLeadStageAndOpportunity($email, $newStage=0, $opportunity=false){
-		if(empty($email)) throw new Exception("Inform lead email as the first argument.");
 
-		$url = $this->getURL('leads').$email;
+  public function updateLeadStageAndOpportunity($email, $newStage=0, $opportunity=false){
+    if(empty($email)) throw new Exception("Inform lead email as the first argument.");
 
-		$data = array(
-			"auth_token" => $this->privateToken,
-			"lead" => array(
-				"lifecycle_stage" => $newStage,
-				"opportunity" => $opportunity
-			)
-		);
+    $url = $this->getURL('leads').$email;
 
-		return $this->request("PUT", $url, $data);
+    $data = array(
+      "auth_token" => $this->privateToken,
+      "lead" => array(
+        "lifecycle_stage" => $newStage,
+        "opportunity" => $opportunity
+      )
+    );
+
+    return $this->request("PUT", $url, $data);
 	}
 
 	/**
@@ -146,22 +148,22 @@ class RDStationAPI {
 	$value: (Integer/Decimal) Purchase value
 	$lostReason: (String)
 	**/
-	public function updateLeadStatus($emailOrLeadId, $status, $value=NULL, $lostReason=NULL) {
-		if(empty($emailOrLeadId)) throw new Exception("Inform lead email or unique custom ID as the first argument.");
-		if(empty($status)) throw new Exception("Inform lead status as the second argument.");
-		else if($status!="won"&&$status!="lost") throw new Exception("Lead status (second argument) should be 'won' or 'lost'.");
+  public function updateLeadStatus($emailOrLeadId, $status, $value=NULL, $lostReason=NULL) {
+    if(empty($emailOrLeadId)) throw new Exception("Inform lead email or unique custom ID as the first argument.");
+    if(empty($status)) throw new Exception("Inform lead status as the second argument.");
+    else if($status!="won"&&$status!="lost") throw new Exception("Lead status (second argument) should be 'won' or 'lost'.");
 
-		$data = array(
-		  "status" => $status,
-		  "value" => $value,
-		  "lost_reason" => $lostReason,
-		);
+    $data = array(
+      "status" => $status,
+      "value" => $value,
+      "lost_reason" => $lostReason,
+    );
 
-		if(is_integer($emailOrLeadId)) $data["lead_id"] = $emailOrLeadId;
-		else $data["email"] = $emailOrLeadId;
+    if(is_integer($emailOrLeadId)) $data["lead_id"] = $emailOrLeadId;
+    else $data["email"] = $emailOrLeadId;
 
-		return $this->request("POST", $this->getURL('generic'), $data);
-	}
+    return $this->request("POST", $this->getURL('generic'), $data);
+  }
 }
 
 ?>

--- a/RDStationAPI.class.php
+++ b/RDStationAPI.class.php
@@ -36,7 +36,7 @@ class RDStationAPI {
 	/**
 	$type:	(String) generic, leads, conversions
 	**/
-  protected function getURL($type='generic', $apiVersion='1.3'){
+  protected function getURL($type='generic', $apiVersion='1.2'){
     //(POST) https://www.rdstation.com.br/api/1.2/services/PRIVATE_TOKEN/generic //USED TO CHANGE A LEAD STATUS
 	  //(PUT) https://www.rdstation.com.br/api/1.2/leads/:lead_email //USED TO UPDATE A LEAD
 		//(POST) https://www.rdstation.com.br/api/1.2/conversions //USED TO SEND A NEW LEAD

--- a/README.md
+++ b/README.md
@@ -5,19 +5,28 @@ $rdAPI = new RDStationAPI("RD_PRIVATE_TOKEN", "RD_TOKEN");
 
 //SEND NEW LEAD TO RD STATION
 $return1 = $rdAPI->sendNewLead("customer@customer.com", array(
-	"nome" => "Julio",
-	"cargo" => "Cofounder",
-	"empresa"=> "Agendor",
+	"name" => "Julio",
+	"job_title" => "Cofounder",
+	"company"=> "Agendor",
 	"identificador" => "contact-form",
 	"subscribe_newsletter" => true //custom data is accepted
 ));
 
+// UPDATE ANY LEAD INFO
+$return2 = $rdAPI->updateLead("customer@customer.com", array(
+    "name" => "New Name",
+    "company"=> "Agendor",
+    "opportunity" => true,
+    "lifecycle_stage" => 1,
+    "Any Custom Field" => "Custom Field Value",
+));
+
 //UPDATE LEAD STATUS TO 'won'
-$return2 = $rdAPI->updateLeadStatus("customer@customer.com", 'won', 999.99);
+$return3 = $rdAPI->updateLeadStatus("customer@customer.com", 'won', 999.99);
 
 //UPDATE LEAD STATUS TO 'lost'
-$return3 = $rdAPI->updateLeadStatus("customer@customer.com", 'lost', 999.99, 'Lost reason');
+$return4 = $rdAPI->updateLeadStatus("customer@customer.com", 'lost', 999.99, 'Lost reason');
 
 //UPDATE LEAD FUNNEL STAGE AND OPPORTUNITY FLAG
-$return4 = $rdAPI->updateLeadStageAndOpportunity("customer@customer.com", 1, true);
+$return5 = $rdAPI->updateLeadStageAndOpportunity("customer@customer.com", 1, true);
 ```

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ $return1 = $rdAPI->sendNewLead("customer@customer.com", array(
 
 // UPDATE ANY LEAD INFO
 $return2 = $rdAPI->updateLead("customer@customer.com", array(
-    "name" => "New Name",
-    "company"=> "Agendor",
-    "opportunity" => true,
-    "lifecycle_stage" => 1,
-    "Any Custom Field" => "Custom Field Value",
+    "lead" => array(
+      "name" => "New Name",
+      "company"=> "Agendor",
+      "opportunity" => true,
+      "lifecycle_stage" => 1,
+      "Any Custom Field" => "Custom Field Value",
+    )
 ));
 
 //UPDATE LEAD STATUS TO 'won'


### PR DESCRIPTION
Permite atualização de qualquer informação do Lead pela API.

Para isto, foi preciso alterar a função `updateLead()`, que antes enviava conversão. Agora esta função envia para um endpoint específico de atualização de Lead, que permite atualizar qualquer informação do Lead.