### PR TITLE
Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ $return1 = $rdAPI->sendNewLead("customer@customer.com", array(
 
 // UPDATE ANY LEAD INFO
 $return2 = $rdAPI->updateLead("customer@customer.com", array(
-    "lead" => array(
-      "name" => "New Name",
-      "company"=> "Agendor",
-      "opportunity" => true,
-      "lifecycle_stage" => 1,
-      "Any Custom Field" => "Custom Field Value",
-    )
+  "name" => "New Name",
+  "company"=> "Agendor",
+  "opportunity" => true,
+  "lifecycle_stage" => 1,
+  "Any Custom Field" => "Custom Field Value"
 ));
 
 //UPDATE LEAD STATUS TO 'won'


### PR DESCRIPTION
## Ajustes na documentação

Removendo o array de campos do updateLead de dentro do array `lead`.

Os campos são adicionados dentro array `lead` dentro do próprio método `updateLead` automaticamente, o usuário não precisa fazer isso. Se fizer, acaba gerando uma requisição com campos duplicados tipo esta e vai dar problema na requisição: `{"lead": "lead": {"name": "Nome do Lead"}}`